### PR TITLE
Changed Add Companies button text to Add/Remove Companies

### DIFF
--- a/app/modals/watchlist.button.jsx
+++ b/app/modals/watchlist.button.jsx
@@ -42,7 +42,7 @@ class WatchlistButton extends React.Component {
     return <Modal
       style={style}
       icon="plus"
-      name="Add Companies"
+      name="Add/Remove Companies"
       onOpen={this.onOpen.bind(this)}
       onClose={this.props.onClose}
       >


### PR DESCRIPTION
I really searched for more than 5 mins in the app to find out the Remove Companies option for the watchlist, finally found that to be hidden inside Add Companies. 

Felt like changing the button text to 'Add/Remove Companies' will help users identify the remove option easily.