### PR TITLE
Add an option to compare Annual Results of a company with another company

### DIFF
--- a/app/company/__tests__/company-tests.js
+++ b/app/company/__tests__/company-tests.js
@@ -1,0 +1,94 @@
+'use strict'
+jest.disableAutomock()
+import React from 'react'
+import ReactDOM from 'react-dom'
+import Results from '../results.jsx'
+import TestUtils from 'react-addons-test-utils'
+
+
+var NUMBERS = [
+  ["Sales",{"2008-03-31":1033.36,"2009-03-31":1002.53}],
+  ["Expenses",{"2008-03-31":915.16,"2009-03-31":1136.98}],
+  ["Material Cost %",{"2008-03-31":11.26,"2009-03-31":11.38}],
+  ["Manufacturing Cost %",{"2008-03-31":8.64,"2009-03-31":8.43}],
+  ["Employee Cost %",{"2008-03-31":91.23,"2009-03-31":98.93}],
+  ["Other Cost %",{"2008-03-31":2.61,"2009-03-31":3.41}],
+  ["Operating Profit",{"2008-03-31":118.2,"2009-03-31":-134.45}],
+  ["OPM",{"2008-03-31":11.44,"2009-03-31":-13.41}]
+]
+
+
+var COMPARENUMBERS = [
+  ["Sales",{"2008-03-31":533.36,"2009-03-31":502.53}],
+  ["Expenses",{"2008-03-31":415.16,"2009-03-31":536.98}],
+  ["Material Cost %",{"2008-03-31":5.26,"2009-03-31":5.38}],
+  ["Manufacturing Cost %",{"2008-03-31":4.64,"2009-03-31":4.43}],
+  ["Employee Cost %",{"2008-03-31":71.23,"2009-03-31":78.93}],
+  ["Other Cost %",{"2008-03-31":2.21,"2009-03-31":3.11}],
+  ["Operating Profit",{"2008-03-31":58.2,"2009-03-31":-74.45}],
+  ["OPM",{"2008-03-31":9.44,"2009-03-31":-11.41}]
+]
+
+describe('Basic rendering Tests', function() {
+  var result
+  var company // https://www.screener.in/api/company/512573/
+  var compareCompany // https://www.screener.in/api/company/539168/
+
+  beforeEach(function() {
+    company = {
+      id: 341,
+      warehouse_set: {
+        result_type: 'sa',
+        pair_url: ''
+      },
+      number_set: {
+        quarters: [["Sales", {}]],
+        annual: NUMBERS
+      },
+      bse_code: "512573",
+      short_name: "Avanti Feeds",
+      name: "Avanti Feeds Ltd"
+    };
+    compareCompany = {
+      id: 1270856,
+      warehouse_set: {
+        result_type: 'sa',
+        pair_url: ''
+      },
+      number_set: {
+        quarters: [["Sales", {}]],
+        annual: COMPARENUMBERS
+      },
+      bse_code: "539168",
+      short_name: "Spisys",
+      name: "Spisys Ltd"
+    };
+  })
+
+  it('Company results without comparing another company', function() {
+    result = TestUtils.renderIntoDocument(
+      <Results company={company} report="annual" />
+    )
+    var dom = ReactDOM.findDOMNode(result)
+    var salesRow = '<tr class="odd"><td class="text">Sales</td><td>1,033.36</td>'
+    var materialRow = '<tr class="percent odd"><td class="text">Material Cost %</td><td>11.26</td>'
+    var normalComparisonRow = 'Spisys Ltd'
+    expect(dom.innerHTML).toContain(salesRow)
+    expect(dom.innerHTML).toContain(materialRow)
+    expect(dom.innerHTML).not.toContain(normalComparisonRow)
+  })
+
+  it('Company results comparing with another company', function() {
+    result = TestUtils.renderIntoDocument(
+      <Results company={company} report="annual" compareCompany={compareCompany} />
+    )
+    var dom = ReactDOM.findDOMNode(result)
+    var salesRow = '<tr class="odd"><td class="text">Sales</td><td class="text">Avanti Feeds Ltd</td><td>1,033.36</td>'
+    var materialRow = '<tr class="percent odd"><td class="text">Material Cost %</td><td class="text">Avanti Feeds Ltd</td><td>11.26</td>'
+    var salesComparisonRow = '<tr class="odd"><td></td><td class="text">Spisys Ltd</td><td>533.36</td>'
+//    console.log(dom.innerHTML)
+    expect(dom.innerHTML).toContain(salesRow)
+    expect(dom.innerHTML).toContain(materialRow)
+    expect(dom.innerHTML).toContain(salesComparisonRow)
+  })
+})

--- a/app/company/results.jsx
+++ b/app/company/results.jsx
@@ -98,7 +98,7 @@ var Results = React.createClass({
       }.bind(this));
   },
 
-  renderRow: function(trailing, dates, childIdx, row, idx) {
+  renderRow: function(trailing, dates, childIdx, numbersCompareCompany, trailingCompareCompany, row, idx) {
     var field = row[0];
     var schedules = this.state.schedules[field];
     var rowClass = classNames({
@@ -112,13 +112,33 @@ var Results = React.createClass({
       return <td key={iidx}>{Utils.toLocalNumber(row[1][rdt])}</td>;
     });
     var TTMCell = trailing ? <td>{trailing[field]}</td> : false;
+    var isCompanyCompared = this.props.compareCompany && this.props.compareCompany.id;
+    var addCompanyName = isCompanyCompared && childIdx === false ? <td className="text">{this.props.company.name}</td> : isCompanyCompared ? <td /> : null;
+    var idxCompare = idx + 50; // Need a good reason for this number
+    var CellsCompare = isCompanyCompared && childIdx === false ? dates.map(function(rdt, iidx) {
+      var cellValue = numbersCompareCompany[idx][1][rdt];
+      return cellValue ? <td key={iidx}>{Utils.toLocalNumber(cellValue)}</td> : <td key={iidx} />;
+    }) : null;
+    var TTMCellCompare = isCompanyCompared && childIdx === false && trailingCompareCompany ? <td>{trailingCompareCompany[field]}</td> : false;
+    var addComparingCompany = isCompanyCompared && childIdx === false ?
+      <tr className={rowClass} key={idxCompare}>
+      <td />
+      <td className="text">{this.props.compareCompany.name}</td>
+      {CellsCompare}
+      {TTMCellCompare}
+    </tr>
+    : null;
+
     return [<tr className={rowClass} key={idx}>
       <td className="text" onClick={this.handleExpand.bind(null, field)}>
         {row[0]}
       </td>
+      {addCompanyName}
       {Cells}
       {TTMCell}
-    </tr>, schedules && schedules.map(this.renderRow.bind(this, trailing, dates, idx))];
+    </tr>,
+    schedules && schedules.map(this.renderRow.bind(this, trailing, dates, idx, null, null)),
+    addComparingCompany];
   },
 
   render: function () {
@@ -129,6 +149,10 @@ var Results = React.createClass({
     var numbers = company.number_set[this.props.report];
     var dates = Object.keys(numbers[0][1]).sort();
     var trailing = getTrailing(this.props.report, company.number_set, dates);
+    var isCompanyCompared = this.props.compareCompany && this.props.compareCompany.id;
+    var blankHeader = isCompanyCompared ? <th /> : null;
+    var numbersCompareCompany = isCompanyCompared ? this.props.compareCompany.number_set[this.props.report] : null;
+    var trailingCompareCompany = isCompanyCompared && trailing ? getTrailing(this.props.report, this.props.compareCompany.number_set, dates) : null;
 
     var Heads = dates.map(function(rdt, idx) {
       return <th key={idx}>{Utils.toMonthYear(rdt)}</th>;
@@ -147,12 +171,13 @@ var Results = React.createClass({
           <thead>
             <tr>
               <th />
+              {blankHeader}
               {Heads}
               {TTMHead}
             </tr>
           </thead>
           <tbody>
-            {numbers.map(this.renderRow.bind(this, trailing, dates, false))}
+            {numbers.map(this.renderRow.bind(this, trailing, dates, false, numbersCompareCompany, trailingCompareCompany))}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
1. Added a label before the CompanySearch component indicating the user can compare the results with another company.
2. Added a button next to CompanySearch component so the user can remove the comparison of the company.
3. Clicking on Sales and Expenses expands and updates the data of the original company. The row for the company being compared with follows at the end and is not expanded.
4. Toggling between Standalone/Consolidated updates the information of the company being compared only if available.