### PR TITLE
Allow users to update screen they own.

### DIFF
--- a/app/modals/savescreen.modal.jsx
+++ b/app/modals/savescreen.modal.jsx
@@ -121,11 +121,13 @@ var SaveScreenModal = React.createClass({
         <div dangerouslySetInnerHTML={this.state.form} />
         <hr />
         <div className="pull-right">
+          <div className="pull-right">
+            &nbsp;&nbsp;
+            <button type="submit" className="btn btn-primary">
+              <i className="glyphicon glyphicon-save" /> {txtSaveBtn}
+            </button>
+          </div>
           {updateBtn}
-          {'  '}
-          <button type="submit" className="btn btn-primary">
-            <i className="glyphicon glyphicon-save" /> {txtSaveBtn}
-          </button>
         </div>
         <Button
           style="danger"

--- a/app/modals/savescreen.modal.jsx
+++ b/app/modals/savescreen.modal.jsx
@@ -20,7 +20,8 @@ var SaveScreenModal = React.createClass({
   getInitialState: function() {
     return {
       form: {__html: '<h3>Loading...</h3>'},
-      updateScreen: undefined,
+      isOwner: true,
+      savedScreen: undefined,
       errors: false
     };
   },
@@ -29,7 +30,10 @@ var SaveScreenModal = React.createClass({
     var screenId = this.props.update;
     if (screenId) {
       Api.get(['screens', screenId]).then(resp => {
-        this.setState({updateScreen: resp.is_owner ? resp : undefined});
+        this.setState({
+          isOwner: resp.is_owner,
+          savedScreen: resp.is_owner ? resp : undefined
+        });
       });
     }
 
@@ -37,6 +41,10 @@ var SaveScreenModal = React.createClass({
       this.setState({
         form: {__html: resp}
       });
+
+      if (screenId) {
+        this.updateForm();
+      }
     });
   },
 
@@ -51,7 +59,7 @@ var SaveScreenModal = React.createClass({
     data.order = screen.order;
     data.sort = screen.sort;
 
-    data.id = this.state.updateScreen.id;
+    data.id = this.state.savedScreen.id;
     var url = 'screens/' + data.id;
     Api.put([url], data).then(
       function(response) {
@@ -80,6 +88,19 @@ var SaveScreenModal = React.createClass({
       }.bind(this));
   },
 
+  updateFields: function() {
+    if(this.state.savedScreen) {
+      this.refs.form.name.value = this.state.savedScreen.name;
+      this.refs.form.description.value = this.state.savedScreen.description;
+    } else if (this.state.isOwner) {
+      this.updateForm();
+    }
+  },
+
+  updateForm: function() {
+    setTimeout( () => this.updateFields(), 200);
+  },
+
   handleCancel: function() {
     this.refs.modal.handleClose();
   },
@@ -87,14 +108,11 @@ var SaveScreenModal = React.createClass({
   render: function() {
     var formCls = this.state.errors && 'has-error';
 
-    var txtSaveBtn = this.state.updateScreen === undefined ? 'Save' : 'Save as new screen';
+    var txtSaveBtn = this.state.savedScreen === undefined ? 'Save' : 'Save as new screen';
     var updateBtn;
-    if(this.state.updateScreen) {
-      // This won't work if the form is not already added.
-      // this.refs.form.name.value = this.state.updateScreen.name;
-      // this.refs.form.description.value = this.state.updateScreen.description;
+    if(this.state.savedScreen) {
       updateBtn = <button type="submit" onClick={this.updateScreen} className="btn btn-primary">
-            <i className="glyphicon glyphicon-save" /> 'Overwrite {this.state.updateScreen.name}'
+            <i className="glyphicon glyphicon-save" /> 'Overwrite {this.state.savedScreen.name}'
           </button>;
     }
 

--- a/app/screens/query.form.jsx
+++ b/app/screens/query.form.jsx
@@ -15,6 +15,10 @@ function QueryForm(props) {
       >Detailed guide on creating stock screens
     </a>
   }
+
+  var is_owner = props.defaults.is_owner;
+  var screenId = is_owner ? props.defaults.id : props.defaults.update;
+
   return <form method="get" action="/screen/raw/">
     <h3>Query Builder</h3>
     <p>You can customize the query below:</p>
@@ -34,6 +38,7 @@ function QueryForm(props) {
           defaultChecked={props.defaults.latest} />
         Show only latest results?
       </label>
+      <input type="hidden" name="update" value={screenId} />
     </div>
     <button className="btn btn-primary" type="submit">
       <i className="glyphicon glyphicon-send"/> Run this query

--- a/app/screens/query.results.jsx
+++ b/app/screens/query.results.jsx
@@ -42,7 +42,7 @@ var Query = React.createClass({
 
   renderLoaded: function() {
     var screen = this.state.screen;
-    var save = <SaveScreenModal screen={screen} />;
+    var save = <SaveScreenModal screen={screen} update={this.props.location.query.update} />;
     var manageCols = <ManageColumns
       onClose={this.onColumnsChange}
       style="default"/>;


### PR DESCRIPTION
1. From a screen, user runs a query. The screen id is passed as a property.
2. When the user attempts to save,  we check if they are the owner of the screen they started from.
3. If they own the screen they started with, the fields 'Name' and 'Description' is pre-populated with current values which they can edit.
4. The user gets to update existing screen or create a new screen.